### PR TITLE
[unscaffold] Remove all `console.log()`s

### DIFF
--- a/tests/dispensations_test.ts
+++ b/tests/dispensations_test.ts
@@ -158,7 +158,6 @@ describe("End-to-end tests", () => {
           }`;
           const mutationDeleteResult = await c.mutation<{isSuccess: string}>(mutationDelete);
           assert(mutationDeleteResult.isSuccess);
-          console.log(mutationDeleteResult);
         }
       }
 
@@ -167,8 +166,6 @@ describe("End-to-end tests", () => {
     it("doesn't make N+1 queries", async () => {
       const dispensations = await q({})
       assert(dispensations.length>0)
-      console.log('disp --> ' + dispensations.length)//77
-      console.log(queries.length)
       assert.isBelow(queries.length, 20)
     })
 

--- a/tests/rooms_test.ts
+++ b/tests/rooms_test.ts
@@ -112,21 +112,17 @@ describe("End-to-end tests", () => {
 
       it("doesn't make N+1 queries", async () => {
 
-        console.log(queries.length)
         const svRooms = await q({building: { equals: "SV"}}, 'kind { name }')
         assert(svRooms.length > 9)
 
-        console.log(svRooms)
         const kinds : { [id : string] : number } = {}
         for (const room of svRooms) {
           const k = room.kind?.name
           kinds[k] = kinds[k] ? kinds[k] + 1 : 1
         }
-        console.log(kinds)
         const kindCount = Object.keys(kinds).length
         assert(kindCount > 5)
 
-        console.log(queries.length)
         assert(queries.length < kindCount)
         assert(queries.some((q) => q.query.includes(' IN (')))
       })


### PR DESCRIPTION
While this is harmless in an IDE such as IntelliJ, console users who run `yarn test` can see these.
