### PR TITLE
[Fix] Replace Id Room with Name Room

### DIFF
--- a/schema/global/rooms.ts
+++ b/schema/global/rooms.ts
@@ -40,7 +40,6 @@ export const RoomStruct = objectType({
 	description: `A room on EPFL campus or any of the satellite locations.`,
 	definition(t) {
 		for (const f of [
-			'id',
 			'name',
 			'building',
 			'sector',

--- a/tests/dispensations_test.ts
+++ b/tests/dispensations_test.ts
@@ -101,7 +101,7 @@ describe("End-to-end tests", () => {
             comment: "Rosa Test comment",
             date_start: "2023-09-07",
             date_end: "2023-09-29",
-            rooms: [{ id: 4 }, { id: 5 }],
+            rooms: [{ name: "BCH 1107" }, { name: "BCH 0407" }],
             holders: [{ sciper: "100192" }, { sciper: "10634" }]
           ) {
             errors {
@@ -130,7 +130,7 @@ describe("End-to-end tests", () => {
               comment: "Rosa Test comment update",
               date_start: "2023-09-07",
               date_end: "2023-09-29",
-              rooms: [{ id: 4 }, { id: 5 }],
+              rooms: [{ name: "BCH 1107" }, { name: "BCH 0405" } ],
               holders: [{ sciper: "100192" }, { sciper: "10634" }]
             ) {
               errors {


### PR DESCRIPTION
The ID of the room was accessible on GraphQL queries. This is a fragile field, in the sense that it is an LHD-made sequence number with no correlation with the EPFL core data set; and as such, it might change as we refactor the database. It has been replaced with the name (**lab_display**) of the room in order to use its identifier common to the entire School information system.